### PR TITLE
Update index.ts

### DIFF
--- a/angular/index.ts
+++ b/angular/index.ts
@@ -121,7 +121,7 @@ export class AccordionComponent {
         }
         if (needDiffer && !this._differ && isListLikeIterable(value)) {
             this._differ = this._iterableDiffers.find(this._items)
-                .create(this._cdr, (_index, item) => { return item; });
+                .create(null, (_index, item) => { return item; });
         }
 
         this.accordion.items = this._items;


### PR DESCRIPTION
Fixes #31 

Fix was based off of what I saw at https://github.com/mujtaba01/ngx-owl-carousel/commit/2e30e6eff18f8735e460376f65c234915fc95355

Looks like they deprecated the ChangeDetectorRef and now you just pass null.